### PR TITLE
Update filtered and random truck generation

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,8 +19,8 @@ Once you are live (no pun intended) in the browser, you will see a scrollable li
 On the root (`/`) view you will note 2 buttons and a search box:
 
 - `PICK FOR ME`: Selects a random truck from the list for you to dine at. It renders your result in the primary card display area.
-- `SEARCH BOX`: Allows user to type an input into the text box and perform a query of the food trucks that match the string entered (ideally an actual food item). If no items match, you will get a message that says `Uh-oh, no matches. Craving something else?` at which point, you can enter a new input, or click either of the other buttons. If you click the search icon without entering at least one character in the search box, you will received a pop-up error message informing you that you need to enter something in the input box in order to execute the search function.
 - `REFRESH`: Allows the user to quickly return to a display of all food tracks.
+- `SEARCH BOX`: Allows user to type an input into the text box and perform a query of the food trucks that match the string entered (ideally an actual food item). If no items match, you will get a message that says `Uh-oh, no matches. Craving something else?` at which point, you can enter a new input, or click either of the other buttons. If you click the search icon without entering at least one character in the search box, you will received a pop-up error message informing you that you need to enter something in the input box in order to execute the search function.
 
 ## **Testing**
 
@@ -28,15 +28,3 @@ A few initial tests have been added. To run the tests execute:
 
 - `mix test` to run all tests once and stop.
 - `mix test.interactive` to run all tests and remain active, watching for additional changes. This option will also allow you to isolate where it is watching for changes, or which files you wish to run tests against. Once it is running, you can simply type `?` in the terminal to see the different options.
-
-## **Next Steps**
-
-Next steps would be:
-
-- Add filtering of results on change in search box, rather than just submit.
-
-- Add ability to be a registered user and favorite trucks/save queries.
-
-- Add more tests, including an end-to-end.
-
-- Add error handling in the event the server crashes or a query fails.

--- a/lib/wheelie_good_eats.ex
+++ b/lib/wheelie_good_eats.ex
@@ -24,19 +24,21 @@ defmodule WheelieGoodEats do
   end
 
   @doc """
-  Fetches all food trucks that match query filter
-  provided by client.
+  Filters for a list of food trucks that match food_type filter
+  provided by client from the list of approved trucks already mounted
+  on socket.
   """
-  @spec show_query(String.t()) :: [Truck.t()]
-  def show_query(filter) do
-    Truck.fetch_query_trucks(filter)
+  @spec show_query(List.t(), String.t()) :: [Truck.t()]
+  def show_query(trucks, filter) do
+    Enum.filter(trucks, fn truck -> String.contains?(truck.food_items, filter) end)
   end
 
   @doc """
-  Fetches a random food truck for the client.
+  Selects a random food truck for the client from the list of approved
+  trucks already mounted on socket.
   """
-  @spec show_random :: Truck.t()
-  def show_random() do
-    Truck.fetch_random_truck()
+  @spec show_random(List.t()) :: Truck.t()
+  def show_random(trucks) do
+    Enum.random(trucks)
   end
 end

--- a/lib/wheelie_good_eats/application.ex
+++ b/lib/wheelie_good_eats/application.ex
@@ -9,13 +9,13 @@ defmodule WheelieGoodEats.Application do
   def start(_type, _args) do
     children = [
       # Start the Telemetry supervisor
-      WheelieGoodEatsWeb.Telemetry,
+      # WheelieGoodEatsWeb.Telemetry,
       # Start the Ecto repository
       WheelieGoodEats.Repo,
       # Start the PubSub system
       {Phoenix.PubSub, name: WheelieGoodEats.PubSub},
       # Start Finch
-      {Finch, name: WheelieGoodEats.Finch},
+      # {Finch, name: WheelieGoodEats.Finch},
       # Start the Endpoint (http/https)
       WheelieGoodEatsWeb.Endpoint
       # Start a worker by calling: WheelieGoodEats.Worker.start_link(arg)

--- a/lib/wheelie_good_eats/truck.ex
+++ b/lib/wheelie_good_eats/truck.ex
@@ -3,8 +3,6 @@ defmodule WheelieGoodEats.Truck do
 
   alias WheelieGoodEats.Repo
 
-  import Ecto.Query, only: [from: 2]
-
   schema "trucks" do
     field(:applicant, :string)
     field(:address, :string)
@@ -27,36 +25,5 @@ defmodule WheelieGoodEats.Truck do
   @spec fetch_all_trucks :: [Ecto.Schema.t()]
   def fetch_all_trucks() do
     Repo.all(WheelieGoodEats.Truck)
-  end
-
-  @doc """
-  Fetches trucks based on a user query for food type.
-
-  In a future iteration if all trucks were in the database, would need to add a filter
-  to the query to return only trucks with approved status.
-  """
-  @spec fetch_query_trucks(String.t()) :: [Ecto.Schema.t()]
-  def fetch_query_trucks(filter) do
-    included = "%#{filter}%"
-
-    from(t in WheelieGoodEats.Truck,
-      select: t,
-      where: ilike(t.food_items, ^included)
-    )
-    |> Repo.all()
-  end
-
-  @doc """
-  Queries for all tracks and returns a randomly selected truck.
-
-  In a future iteration if all trucks were in the database, would need to add a filter
-  to return only trucks with approved status. Additionally the approach may require a
-  refactor to optimize performance if the number of trucks in the database increased
-  significantly.
-  """
-  @spec fetch_random_truck :: Ecto.Schema.t()
-  def fetch_random_truck() do
-    fetch_all_trucks()
-    |> Enum.random()
   end
 end

--- a/lib/wheelie_good_eats_web.ex
+++ b/lib/wheelie_good_eats_web.ex
@@ -30,25 +30,6 @@ defmodule WheelieGoodEatsWeb do
     end
   end
 
-  def channel do
-    quote do
-      use Phoenix.Channel
-    end
-  end
-
-  def controller do
-    quote do
-      use Phoenix.Controller,
-        formats: [:html, :json],
-        layouts: [html: WheelieGoodEatsWeb.Layouts]
-
-      import Plug.Conn
-      import WheelieGoodEatsWeb.Gettext
-
-      unquote(verified_routes())
-    end
-  end
-
   def live_view do
     quote do
       use Phoenix.LiveView,

--- a/lib/wheelie_good_eats_web/live/trucks_live.ex
+++ b/lib/wheelie_good_eats_web/live/trucks_live.ex
@@ -5,44 +5,43 @@ defmodule WheelieGoodEatsWeb.TrucksLive do
   def mount(_params, _session, socket) do
     trucks = WheelieGoodEats.show_all()
     craving = WheelieGoodEats.new_craving()
-    selected_truck = ""
 
     {:ok,
      assign(socket, :trucks, trucks)
      |> assign(:form, to_form(craving))
-     |> assign(:selected, selected_truck)}
+     |> assign(:filtered_trucks, nil)
+     |> assign(:random_truck, nil)}
   end
 
   def handle_event("query", %{"craving" => craving}, socket) do
-    if craving["food_type"] != "" do
-      reset_selected = ""
-      query_trucks = WheelieGoodEats.show_query(craving["food_type"])
+    if craving["food_type"] != nil do
+      query_trucks = WheelieGoodEats.show_query(socket.assigns.trucks, craving["food_type"])
       reset_craving = WheelieGoodEats.new_craving()
 
       {:noreply,
-       assign(socket, :trucks, query_trucks)
+       assign(socket, :filtered_trucks, query_trucks)
        |> assign(:form, to_form(reset_craving))
-       |> assign(:selected, reset_selected)}
+       |> assign(:random_truck, nil)}
     else
       {:noreply, put_flash(socket, :error, "Cannot be empty.")}
     end
   end
 
   def handle_event("random", _unsigned_params, socket) do
-    selected_truck = WheelieGoodEats.show_random()
+    trucks = socket.assigns.trucks
+    selected_truck = WheelieGoodEats.show_random(trucks)
 
-    {:noreply, assign(socket, :selected, selected_truck)}
-    # {:noreply, socket |> redirect(to: "/winner")}
+    {:noreply,
+     assign(socket, :random_truck, selected_truck)
+     |> assign(:filtered_trucks, nil)}
   end
 
   def handle_event("refresh", _unsigned_params, socket) do
-    all_trucks = WheelieGoodEats.show_all()
     reset_craving = WheelieGoodEats.new_craving()
-    reset_selected = ""
 
     {:noreply,
-     assign(socket, :trucks, all_trucks)
-     |> assign(:form, to_form(reset_craving))
-     |> assign(:selected, reset_selected)}
+     assign(socket, :form, to_form(reset_craving))
+     |> assign(:filtered_trucks, nil)
+     |> assign(:random_truck, nil)}
   end
 end

--- a/lib/wheelie_good_eats_web/live/trucks_live.html.heex
+++ b/lib/wheelie_good_eats_web/live/trucks_live.html.heex
@@ -30,34 +30,32 @@
     </.button>
   </header>
   <%= cond do %>
-    <% is_binary(@selected) -> %>
-      <%= if length(@trucks) != 0 do %>
-        <div class="truck grid grid-cols-4 gap-4 mt-4 mx-4">
-          <%= for truck <- @trucks do %>
-            <div class="bg-emerald-50 flex flex-col items-center text-center py-2 px-2 border rounded-md space-y-2">
-              <p class="text-xl font-bold text-emerald-950"><%= truck.applicant %></p>
-              <p class="text-emerald-950"><%= truck.address %></p>
-              <p class="italic text-emerald-950">Menu includes: <%= truck.food_items %></p>
-            </div>
-          <% end %>
-        </div>
-      <% else %>
-        <div>
-          <h1 class="text-center text-5xl font-bold leading-normal mt-3 mb-0 text-emerald-50">
-            Uh-oh, no matches. Craving something else?
-          </h1>
-        </div>
-      <% end %>
-    <% is_struct(@selected) -> %>
+    <% @random_truck != nil -> %>
       <div class="grid w-screen place-items-center">
         <h4 class="italic text-2xl font-normal leading-normal mt-5 mb-0 text-emerald-50">
           Enjoy dining at:
         </h4>
         <div class="bg-emerald-50 flex flex-col items-center text-center border rounded-md space-y-2 mt-3 mb-10 ml-10 mr-10 px-10 py-10">
-          <p class="text-xl font-bold text-emerald-950"><%= @selected.applicant %></p>
-          <p class="text-emerald-950"><%= @selected.address %></p>
-          <p class="text-emerald-950">Menu includes: <%= @selected.food_items %></p>
+          <p class="text-xl font-bold text-emerald-950"><%= @random_truck.applicant %></p>
+          <p class="text-emerald-950"><%= @random_truck.address %></p>
+          <p class="text-emerald-950">Menu includes: <%= @random_truck.food_items %></p>
         </div>
+      </div>
+    <% @filtered_trucks != nil && length(@filtered_trucks) == 0 -> %>
+      <div>
+        <h1 class="text-center text-5xl font-bold leading-normal mt-3 mb-0 text-emerald-50">
+          Uh-oh, no matches. Craving something else?
+        </h1>
+      </div>
+    <% true -> %>
+      <div class="truck grid grid-cols-4 gap-4 mt-4 mx-4">
+        <%= for truck <- if @filtered_trucks != nil, do: @filtered_trucks, else: @trucks do %>
+          <div class="bg-emerald-50 flex flex-col items-center text-center py-2 px-2 border rounded-md space-y-2">
+            <p class="text-xl font-bold text-emerald-950"><%= truck.applicant %></p>
+            <p class="text-emerald-950"><%= truck.address %></p>
+            <p class="italic text-emerald-950">Menu includes: <%= truck.food_items %></p>
+          </div>
+        <% end %>
       </div>
   <% end %>
 </div>

--- a/test/wheelie_good_eats/truck_test.exs
+++ b/test/wheelie_good_eats/truck_test.exs
@@ -29,19 +29,4 @@ defmodule WheelieGoodEats.TruckTest do
       end
     end
   end
-
-  describe "fetch_query_trucks/1" do
-    test "should return only truck(s) that contain input in food_items" do
-      input = "tacos"
-      result = Truck.fetch_query_trucks(input) |> List.first()
-      assert String.contains?(result.food_items, input)
-    end
-  end
-
-  describe "fetch_random_truck/0" do
-    test "should return only one truck" do
-      result = Truck.fetch_random_truck()
-      assert is_struct(result, Truck)
-    end
-  end
 end

--- a/test/wheelie_good_eats_test.exs
+++ b/test/wheelie_good_eats_test.exs
@@ -1,0 +1,53 @@
+defmodule WheelieGoodEatsTest do
+  use ExUnit.Case
+
+  import WheelieGoodEats.Factory
+
+  import WheelieGoodEats
+
+  setup do
+    :ok = Ecto.Adapters.SQL.Sandbox.checkout(WheelieGoodEats.Repo)
+
+    insert!(:truck)
+    insert!(:truck)
+    insert!(:truck, food_items: "tacos")
+
+    :ok
+  end
+
+  describe "new_craving/0" do
+    test "should return a changeset with key of food_type and value of nil" do
+      result = new_craving()
+      assert Map.has_key?(result.data, :food_type)
+      assert result.data.food_type == nil
+    end
+  end
+
+  describe "show_query/2" do
+    setup do
+      %{trucks: show_all()}
+    end
+
+    test "should return list of trucks that matches food_type filter", %{trucks: trucks} do
+      input = "tacos"
+      result = show_query(trucks, input) |> List.first()
+      assert String.contains?(result.food_items, input)
+    end
+
+    test "should return an empty list if no trucks match food_type filter", %{trucks: trucks} do
+      input = "pho"
+      result = show_query(trucks, input)
+      assert is_list(result)
+      assert Enum.empty?(result)
+    end
+  end
+
+  describe "show_random/1" do
+    test "should return a truck from the list of trucks" do
+      trucks = show_all()
+
+      result = show_random(trucks)
+      assert is_struct(result, WheelieGoodEats.Truck)
+    end
+  end
+end


### PR DESCRIPTION
To minimize hits on the database this refactor adds additional keys to the socket so that the original list of approved trucks mounted to socket can be used for the generation of filtered truck list and the randomly selected truck. 